### PR TITLE
All open borrow requests can be displayed

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -68,12 +68,19 @@ module Types
       Item.where(posting_id: ids)
     end
 
-    field :items_user_has_borrowed, [Types::ItemType], null: false, description: "Returns all borrow postings where lender has responded to borrower" do
+    field :items_user_has_borrowed, [Types::ItemType], null: false, description: "Returns all borrow postings for a user where lender has responded to their borrow posting" do
       argument :user_id, ID, required: true
     end
 
     def items_user_has_borrowed(user_id:)
       ids = Posting.where(responder_id: user_id).ids
+      Item.where(posting_id: ids)
+    end
+
+    field :get_all_open_borrow_requests, [Types::ItemType], null: false, description: "Returns all borrow postings which have not yet been responded to by a lender"
+
+    def get_all_open_borrow_requests
+      ids = Posting.where(responder_id: nil, posting_type: "borrow").ids
       Item.where(posting_id: ids)
     end
 

--- a/spec/graphql/queries/postings/borrow/get_all_borrow_postings_lender_has_not_responded_to_spec.rb
+++ b/spec/graphql/queries/postings/borrow/get_all_borrow_postings_lender_has_not_responded_to_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe Types::QueryType do
+  describe 'display postings' do
+    it 'user can query all their borrow postings' do
+      lawn = Category.create(name: 'Lawn Care')
+      @user = User.create(first_name: 'Carole', last_name: 'Baskin', email: 'carole@tigers.com', password: 'password', zip: 80206)
+      @user1 = User.create(first_name: 'Joe', last_name: 'Exotic', email: 'joe4president@gmail.com', password: 'password', zip: 80206)
+
+      posting = Posting.create(posting_type: 0, title: "Looking to borrow a mower", poster_id: @user.id)
+      posting1 = Posting.create(posting_type: 0, title: "Looking to borrow a sprinkler", poster_id: @user.id)
+      posting2 = Posting.create(posting_type: 0, title: "Looking to borrow another sprinkler", poster_id: @user.id)
+      posting3 = Posting.create(posting_type: 0, title: "Looking to borrow yet another sprinkler", poster_id: @user1.id)
+      posting4 = Posting.create(posting_type: 0, title: "Looking to borrow a shovel", poster_id: @user.id, responder_id: @user1.id)
+
+      lawn.items.create(name: 'Mower', quantity: 12.5, time_duration: 'hours', available: true, posting_id: posting.id)
+      lawn.items.create(name: 'Sprinkler', quantity: 2.0, time_duration: 'days', available: true, posting_id: posting1.id)
+      lawn.items.create(name: 'Sprinkler', quantity: 2.0, time_duration: 'days', available: true, posting_id: posting2.id)
+      lawn.items.create(name: 'Shovel', quantity: 2.0, time_duration: 'days', available: true, posting_id: posting3.id)
+      lawn.items.create(name: 'Sprinkler', quantity: 2.0, time_duration: 'days', available: true, posting_id: posting4.id)
+
+
+      result = CupOfSugarBeSchema.execute(query).as_json
+
+      postings = result["data"]["getAllOpenBorrowRequests"]
+
+      expect(postings.count).to eq(4)
+      expect(postings[0]["posting"]["title"]).to eq(posting.title)
+      expect(postings[0]).to have_key("name")
+      expect(postings[0]).to have_key("quantity")
+      expect(postings[0]).to have_key("available")
+      expect(postings[0]).to have_key("description")
+      expect(postings[0]).to have_key("measurement")
+      expect(postings[0]).to have_key("timeDuration")
+      expect(postings[1]["posting"]["title"]).to eq(posting1.title)
+      expect(postings[2]["posting"]["title"]).to eq(posting2.title)
+      expect(postings).not_to include(posting4)
+    end
+  end
+
+  def query
+    <<~GQL
+    query {
+      getAllOpenBorrowRequests {
+        name
+        quantity
+        available
+        description
+        measurement
+        timeDuration
+        posting {
+          title
+        }
+      }
+    }
+    GQL
+  end
+end


### PR DESCRIPTION
## Summary of functionality
- This query allows all borrow postings/items which do not have a responder_id to be displayed.

## Testing status
Coverage: 98.86%

All tests passing?
- [X] yes
- [ ] no
## Issues
closes #63 

## Gif of how I feel submitting this
![pinguuuu](https://media0.giphy.com/media/TVPJNp47j5EA0/giphy.gif?cid=ecf05e47e5b4c82aa37f8396d012f9212772dcee8ca4bd7e&rid=giphy.gif)
