### PR TITLE
Posting id bug fix

### DIFF
--- a/app/graphql/types/item_type.rb
+++ b/app/graphql/types/item_type.rb
@@ -10,6 +10,7 @@ module Types
     field :returnable, Boolean, null: false
     field :category, Types::CategoryType, null: false
     field :returnable, Boolean, null: false
+    field :posting_id, ID, null: false
 
     field :posting, Types::PostingType, null: true
   end

--- a/spec/graphql/queries/items/get_all_items_by_name_spec.rb
+++ b/spec/graphql/queries/items/get_all_items_by_name_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe Types::QueryType do
     <<~GQL
     query {
       getAllItemsByName(itemName: "Ralph") {
+        postingId
         name
         quantity
         timeDuration
@@ -63,6 +64,7 @@ RSpec.describe Types::QueryType do
     <<~GQL
     query {
       getAllItemsByName(itemName: "Mower") {
+        postingId
         name
         quantity
         timeDuration

--- a/spec/graphql/queries/items/get_all_items_in_category_spec.rb
+++ b/spec/graphql/queries/items/get_all_items_in_category_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe Types::QueryType do
         measurement
         description
         available
+        postingId
       }
     }
     GQL
@@ -82,6 +83,7 @@ RSpec.describe Types::QueryType do
         measurement
         description
         available
+        postingId
       }
     }
     GQL

--- a/spec/graphql/queries/items/get_all_items_spec.rb
+++ b/spec/graphql/queries/items/get_all_items_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Types::QueryType do
       expect(items[0]["category"]["name"]).to eq("Cats")
       expect(items[1]["description"]).to eq("this cat is the worst but I love him.")
       expect(items[1]["timeDuration"]).to eq("days")
-    end 
+    end
   end
 
   def query
@@ -38,6 +38,7 @@ RSpec.describe Types::QueryType do
         description
         measurement
         timeDuration
+        postingId
         category {
           name
         }

--- a/spec/graphql/queries/postings/borrow/get_all_borrow_postings_lender_has_not_responded_to_spec.rb
+++ b/spec/graphql/queries/postings/borrow/get_all_borrow_postings_lender_has_not_responded_to_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe Types::QueryType do
         measurement
         timeDuration
         posting {
+          id
           title
         }
       }

--- a/spec/graphql/queries/postings/borrow/user_can_view_all_borrow_postings_spec.rb
+++ b/spec/graphql/queries/postings/borrow/user_can_view_all_borrow_postings_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe Types::QueryType do
         measurement
         timeDuration
         posting {
+          id
           title
         }
       }

--- a/spec/graphql/queries/postings/borrow/user_can_view_all_posts_they_have_responded_to_spec.rb
+++ b/spec/graphql/queries/postings/borrow/user_can_view_all_posts_they_have_responded_to_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Types::QueryType do
         measurement
         timeDuration
         posting {
+          id
           title
         }
       }

--- a/spec/graphql/queries/postings/borrow/user_can_view_borrow_posts_which_have_not_been_responded_to_spec.rb
+++ b/spec/graphql/queries/postings/borrow/user_can_view_borrow_posts_which_have_not_been_responded_to_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Types::QueryType do
         measurement
         timeDuration
         posting {
+          id
           title
         }
         category {

--- a/spec/graphql/queries/postings/lend/user_can_view_all_lend_postings_spec.rb
+++ b/spec/graphql/queries/postings/lend/user_can_view_all_lend_postings_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Types::QueryType do
         measurement
         timeDuration
         posting {
+          id
           title
         }
       }

--- a/spec/graphql/queries/postings/lend/user_can_view_all_posts_they_have_responded_to_spec.rb
+++ b/spec/graphql/queries/postings/lend/user_can_view_all_posts_they_have_responded_to_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Types::QueryType do
         measurement
         timeDuration
         posting {
+          id
           title
         }
       }


### PR DESCRIPTION
## Summary of functionality
- FE was unable to delete postings because they were not being passed a a posting id
- Updates all posting and item queries to return posting ids to resolve this issue

## Testing status
Coverage: 98.92%

All tests passing?
- [X] yes
- [ ] no
## Issues
closes #67 
