### PR TITLE
Add token response

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,7 @@
 class ApplicationController < ActionController::API
+
+  def current_user
+   token = request.headers["Authorization"]
+   AuthToken.user_from_token(token)
+ end
 end

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -8,9 +8,9 @@ class GraphqlController < ApplicationController
     variables = ensure_hash(params[:variables])
     query = params[:query]
     operation_name = params[:operationName]
+
     context = {
-      # Query context goes here, for example:
-      # current_user: current_user
+      current_user: current_user
     }
     result = CupOfSugarBeSchema.execute(query, variables: variables, context: context, operation_name: operation_name)
 

--- a/app/graphql/mutations/messages/send_message.rb
+++ b/app/graphql/mutations/messages/send_message.rb
@@ -4,14 +4,18 @@ module Mutations
       argument :title, String, required: true
       argument :body, String, required: true
       argument :userId, ID, required: true
-      argument :recipientId, ID, required: true
+      argument :recipientEmail, ID, required: true
 
       field :id, ID, null: false
       field :title, String, null: false
       field :body, String, null: false
 
       def resolve(params)
-        Message.create(title: params[:title], body: params[:body], sender_id: params[:userId], recipient_id: params[:recipientId])
+        Message.create(
+          title: params[:title],
+          body: params[:body],
+          sender_id: params[:userId],
+          recipient_id: User.find_by(email: params[:recipientEmail]).id)
       end
     end
   end

--- a/app/graphql/mutations/users/user_login.rb
+++ b/app/graphql/mutations/users/user_login.rb
@@ -1,19 +1,20 @@
 module Mutations
   module Users
     class UserLogin < ::Mutations::BaseMutation
-      argument :email, String, required: true
-      argument :password, String, required: true
+      null true
 
-      field :email, String, null: true
-      field :id, ID, null: false
+      argument :credentials, Types::AuthProviderCredentialsInput, required: false
+
+      field :user, Types::UserType, null: true
+      field :token, String, null: true
 
       def resolve(params)
         user = User.verify_login(params)
-        if user == false
-          { "email"=> nil }
-        else
-          user
-        end
+        return unless user
+
+        token = AuthToken.token_for_user(user)
+
+        { user: user, token: token }
       end
     end
   end

--- a/app/graphql/types/auth_provider_credentials_input.rb
+++ b/app/graphql/types/auth_provider_credentials_input.rb
@@ -1,0 +1,9 @@
+module Types
+  class AuthProviderCredentialsInput < BaseInputObject
+
+    graphql_name 'AUTH_PROVIDER_CREDENTIALS'
+
+    argument :email, String, required: true
+    argument :password, String, required: true
+  end
+end

--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -1,0 +1,24 @@
+module AuthToken
+  module_function
+
+  PREFIX = 'user-id'.freeze
+
+  def token_for_user(user)
+    crypt.encrypt_and_sign("#{PREFIX}#{user.id}")
+  end
+
+  def user_from_token(token)
+    return if token.blank?
+
+    user_id = crypt.decrypt_and_verify(token).gsub(PREFIX, '').to_i
+    User.find_by id: user_id
+  rescue ActiveSupport::MessageVerifier::InvalidSignature
+    nil
+  end
+
+  def crypt
+    ActiveSupport::MessageEncryptor.new(
+      Rails.application.secrets.secret_key_base.byteslice(0..31)
+    )
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,11 +18,9 @@ class User < ApplicationRecord
   has_secure_password
 
   def self.verify_login(params)
-    user = User.find_by(email: params[:email])
-    if user
-      user.authenticate(params[:password])
-    else
-      false
-    end
+    user = User.find_by(email: params[:credentials][:email])
+    return unless user
+    
+    user.authenticate(params[:credentials][:password])
   end
 end

--- a/spec/graphql/mutations/messages/user_can_send_a_message_spec.rb
+++ b/spec/graphql/mutations/messages/user_can_send_a_message_spec.rb
@@ -27,7 +27,7 @@ module Mutations
               title: "Borrowing your drill"
               body: "Thanks so much for letting me borrow your drill. Can I pick it up on Saturday?"
               userId: "#{@user.id}"
-              recipientId: "#{@user1.id}"
+              recipientEmail: "#{@user1.email}"
             }
           )
           {

--- a/spec/graphql/mutations/users/user_can_log_in_spec.rb
+++ b/spec/graphql/mutations/users/user_can_log_in_spec.rb
@@ -8,10 +8,11 @@ module Mutations
           user = User.create(first_name: 'Carole', last_name: 'Baskin', email: 'carole@tigers.com', password: 'password', zip: 80206)
 
           post "/graphql", params: { query: query }
+
           result = JSON.parse(response.body, symbolize_names: true)
 
-          expect(result[:data][:user][:email]).to eq("carole@tigers.com")
-          expect(result[:data][:user][:id]).to eq(user.id.to_s)
+          expect(result[:data][:user][:token].length).to eq(72)
+          expect(result[:data][:user][:user][:id]).to eq(user.id.to_s)
           expect(result[:data][:user].count).to eq(2)
         end
       end
@@ -21,15 +22,19 @@ module Mutations
         mutation {
           user: userLogin(
             input: {
-              email: "carole@tigers.com"
-              password: "password"
+               credentials: {
+                email: "carole@tigers.com"
+                password: "password"
+              }
             }
           )
           {
-            id
-            email
+            token
+              user {
+                id
+              }
+            }
           }
-        }
         GQL
       end
 
@@ -39,8 +44,7 @@ module Mutations
 
           post "/graphql", params: { query: query1 }
           result = JSON.parse(response.body, symbolize_names: true)
-
-          expect(result[:data][:user][:email]).to eq(nil)
+          expect(result[:data][:user]).to eq(nil)
         end
       end
 
@@ -49,14 +53,19 @@ module Mutations
         mutation {
           user: userLogin(
             input: {
-              email: "carole@tigers.com"
-              password: "pass"
+               credentials: {
+                email: "carole@tigers.com"
+                password: "passwd"
+              }
             }
           )
           {
-            email
+            token
+              user {
+                id
+              }
+            }
           }
-        }
         GQL
       end
 
@@ -67,7 +76,7 @@ module Mutations
           post "/graphql", params: { query: query2 }
           result = JSON.parse(response.body, symbolize_names: true)
 
-          expect(result[:data][:user][:email]).to eq(nil)
+          expect(result[:data][:user]).to eq(nil)
         end
       end
 
@@ -76,14 +85,19 @@ module Mutations
         mutation {
           user: userLogin(
             input: {
-              email: "carole@tigers"
-              password: "password"
+               credentials: {
+                email: "carole@tigers"
+                password: "password"
+              }
             }
           )
           {
-            email
+            token
+              user {
+                id
+              }
+            }
           }
-        }
         GQL
       end
 
@@ -94,7 +108,7 @@ module Mutations
           post "/graphql", params: { query: query3 }
           result = JSON.parse(response.body, symbolize_names: true)
 
-          expect(result[:data][:user][:email]).to eq(nil)
+          expect(result[:data][:user]).to eq(nil)
         end
       end
 
@@ -103,14 +117,19 @@ module Mutations
         mutation {
           user: userLogin(
             input: {
-              email: "carole@tigers"
-              password: "pass"
+               credentials: {
+                email: "carole@tigers"
+                password: "password"
+              }
             }
           )
           {
-            email
+            token
+              user {
+                id
+              }
+            }
           }
-        }
         GQL
       end
     end


### PR DESCRIPTION
## Summary of functionality
- Added token generation upon user sign in, this token is returned to the front end who will need to include the token in the authorization header.
- Added current_user to context in graphql_controller, context[:current_user] can now be used in place of all instances of user_id in queries. 
- Updated sendMessage mutation to take argument of recipientEmail instead of recipientId
## Testing status
Coverage: 98.45%

All tests passing?
- [X] yes
- [ ] no
## Issues
creates #69 
closes #55 #71 

## Gif of how I feel submitting this
![alt text](https://media.giphy.com/media/tHWM5JrFZ96Ks/giphy.gif)
